### PR TITLE
recursive dependency download option

### DIFF
--- a/factoriomod.py
+++ b/factoriomod.py
@@ -1,5 +1,5 @@
-import requests, json, os, sys, shutil, traceback
-
+import requests, json, os, sys, shutil, traceback, hashlib, platform
+from pathlib import Path
 MAX_RELEASES_DISPLAYED = 3
 MAX_WORDS_PER_LINE = 6
 
@@ -16,8 +16,11 @@ token = ""
 
 factorio_path = ""
 
-def getModInfo(name) :
-	request = requests.get("https://mods.factorio.com/api/mods/" + name.replace(" ", "%20"))
+def getModInfo(name,detailed=False) :
+	query = "https://mods.factorio.com/api/mods/" + name.replace(" ", "%20")
+	if detailed: query+='/full'
+	request = requests.get(query)
+	
 	result = json.loads(request.text)
 	return result
 
@@ -56,7 +59,9 @@ def setFactorioPath() :
 	factorio_path = path
 	saveUserdata()
 	print("Path changed!")
-
+def checkFactorioPath(path):
+	return os.path.isdir(path) and  ("mods" and "player-data.json" in os.listdir(path))
+			
 def saveUserdata() :
 	global username, token, factorio_path
 	
@@ -78,6 +83,19 @@ def loadUserdata() :
 		username = data.get("username", "")
 		token = data.get("token", "")
 		factorio_path = data.get("path", "")
+	if not checkFactorioPathSet():
+		auto_path = "."
+		if platform.system() == 'Darwin':
+			auto_path = os.path.join(Path.home(),"Library/Application Support/factorio")
+		elif platform.system() == "Linux":
+			auto_path = os.path.join(Path.home(),"factorio")
+		elif platform.system() == 'Windows':
+			auto_path = os.path.join(Path.home(),"AppData/Roaming/Factorio")
+		if checkFactorioPath(auto_path):
+			factorio_path = auto_path
+			
+		
+
 
 def checkCredentialsSet() :
 	global username, token
@@ -140,38 +158,99 @@ def clearCache() :
 	if os.path.isdir("mod_cache") :
 		shutil.rmtree("mod_cache")
 		checkDirs()
+def hash_file(filename):
+   """"This function returns the SHA-1 hash
+   of the file passed into it"""
 
-def downloadMod(packet) :
+   # make a hash object
+   h = hashlib.sha1()
+
+   # open file for reading in binary mode
+   with open(filename,'rb') as file:
+
+       # loop till the end of the file
+       chunk = 0
+       while chunk != b'':
+           # read only 1024 bytes at a time
+           chunk = file.read(1024)
+           h.update(chunk)
+
+   # return the hex representation of digest
+   return h.hexdigest()
+
+def downloadMod(packet,latest=False) :
 	global username, token
-	
-	displayModInfo(packet)
+
 	vers = ""
-	while True :
-		check = False
-		vers = input("\nSelect release to download: ").strip()
-		for rl in packet["releases"] :
-			if rl["version"] == vers :
-				check = True
-		if check :
-			break
-		print("Version not released")
-		
+	if not latest:
+		while True :
+			check = False
+			vers = input("\nSelect release to download: ").strip()
+			for rl in packet["releases"] :
+				if rl["version"] == vers :
+					check = True
+			if check :
+				break
+			print("Version not released")
+	else:
+		versions = [rl["version"] for rl in packet["releases"]]
+		versions.sort()
+		vers = versions[-1]
+
 	release = None
 	for rl in  packet["releases"] :
 		if rl["version"] == vers :
 				release = dict(rl)
 		
 	url = "http://mods.factorio.com" + release["download_url"] + "?username=" + username + "&token=" + token
-	
+	output_path = "mod_cache" + os.sep + release["file_name"]
+	if os.path.isfile(output_path):
+		sha1 = release['sha1']
+		if sha1==hash_file(output_path):
+			print('Using cached version')
+			return release["file_name"]
+		
 	request = requests.get(url)
 	request.raise_for_status()
-	with open("mod_cache" + os.sep + release["file_name"], "wb") as file:
+	with open(output_path, "wb") as file:
+		
 		for chunk in request.iter_content(4096) :
 			file.write(chunk)
 
+
 	print("Mod downloaded successfully")
 	return release["file_name"]
+def download_recursive_mod(mod_name,install_mod=False,visited_set=None):
+    if visited_set is None:
+        visited_set = set()
+    if mod_name in visited_set:
+        return
+    visited_set.add(mod_name)
+    
+    mod_info = getModInfo(mod_name,detailed=True)
+    print(f"Downloading {mod_name}...")
+    try:
+        file_name = downloadMod(mod_info,latest=True)
+        if install_mod:
+            installMod(file_name)
+    except Exception as e:
+        print("#"*33)
+        print(f"Error in downloading {mod_name}")
+        print(e)
+        print("#"*33)
+        return
 
+    versions_idx = list(range(len(mod_info["releases"])))
+    versions_idx.sort(key=lambda x: mod_info["releases"][x]["version"],reverse=True)
+    rel = mod_info["releases"][versions_idx[0]]
+    mod_rel_info = rel['info_json']
+    if 'dependencies' in mod_rel_info:
+        for dep_code in mod_rel_info['dependencies']:
+
+            for dep in dep_code.split(" "):
+
+                if dep.isalnum() and dep!='base':
+                    download_recursive_mod(dep,visited_set=visited_set,install_mod=install_mod)
 def installMod(filename) :
 	global factorio_path
 	
@@ -216,31 +295,29 @@ def start() :
 	if opt == 0 :
 		sys.exit(0)
 
-	elif opt == 1 :
-		if (not checkCredentialsSet()) or (not checkFactorioPathSet()) :
-			print("You need to set the credentials and the factorio path in order to install a mod!")
-			return
-		
-		try :
-			packet = askModName()
-			print()
-		except KeyboardInterrupt :
-			return
-		
-		installMod(downloadMod(packet))
-		
-	elif opt == 2:
+	if opt == 1 or opt ==2:
 		if not checkCredentialsSet() :
 			print("You need to set the credentials in order to download a mod!")
 			return
-		
+		if opt == 1 :
+			if not checkFactorioPathSet() :
+				print("You need to set the factorio path in order to install a mod!")
+				return
+			install_mod = True
+		elif opt == 2:
+			install_mod = False
+			
 		try :
 			packet = askModName()
 			print()
 		except KeyboardInterrupt :
 			return
 
-		downloadMod(packet)
+		# downloadMod(packet)		
+		download_recursive_mod(packet['name'],install_mod=install_mod)
+		
+	
+		
 	
 	elif opt == 3:
 		try :

--- a/factoriomod.py
+++ b/factoriomod.py
@@ -17,8 +17,7 @@ token = ""
 factorio_path = ""
 
 def getModInfo(name,detailed=False) :
-	query = "https://mods.factorio.com/api/mods/" + name.replace(" ", "%20")
-	if detailed: query+='/full'
+	query = "https://mods.factorio.com/api/mods/" + name.replace(" ", "%20") + ("/full" if detailed else "")
 	request = requests.get(query)
 	
 	result = json.loads(request.text)
@@ -27,7 +26,7 @@ def getModInfo(name,detailed=False) :
 def isErrorPacket(modpacket) :
 	return "message" in modpacket.keys()
 
-def login() :
+def login():
 	global username, token
 	
 	print("Insert below your Factorio account data (NOT NECESSARALY PREMIUM)")
@@ -183,6 +182,11 @@ def downloadMod(packet,latest=False) :
 
 	vers = ""
 	if not latest:
+		# Inform the user about available releases 
+		# when going interactive mode
+		displayModInfo(packet)
+		print()
+
 		while True :
 			check = False
 			vers = input("\nSelect release to download: ").strip()

--- a/factoriomod.py
+++ b/factoriomod.py
@@ -59,6 +59,7 @@ def setFactorioPath() :
 	factorio_path = path
 	saveUserdata()
 	print("Path changed!")
+
 def checkFactorioPath(path):
 	return os.path.isdir(path) and  ("mods" and "player-data.json" in os.listdir(path))
 			
@@ -83,6 +84,7 @@ def loadUserdata() :
 		username = data.get("username", "")
 		token = data.get("token", "")
 		factorio_path = data.get("path", "")
+
 	if not checkFactorioPathSet():
 		auto_path = "."
 		if platform.system() == 'Darwin':
@@ -93,9 +95,6 @@ def loadUserdata() :
 			auto_path = os.path.join(Path.home(),"AppData/Roaming/Factorio")
 		if checkFactorioPath(auto_path):
 			factorio_path = auto_path
-			
-		
-
 
 def checkCredentialsSet() :
 	global username, token
@@ -158,25 +157,26 @@ def clearCache() :
 	if os.path.isdir("mod_cache") :
 		shutil.rmtree("mod_cache")
 		checkDirs()
+		
 def hash_file(filename):
-   """"This function returns the SHA-1 hash
-   of the file passed into it"""
+	""""This function returns the SHA-1 hash
+	of the file passed into it"""
 
-   # make a hash object
-   h = hashlib.sha1()
+	# make a hash object
+	h = hashlib.sha1()
 
-   # open file for reading in binary mode
-   with open(filename,'rb') as file:
+	# open file for reading in binary mode
+	with open(filename,'rb') as file:
 
-       # loop till the end of the file
-       chunk = 0
-       while chunk != b'':
-           # read only 1024 bytes at a time
-           chunk = file.read(1024)
-           h.update(chunk)
+		# loop till the end of the file
+		chunk = 0
+		while chunk != b'':
+			# read only 1024 bytes at a time
+			chunk = file.read(1024)
+			h.update(chunk)
 
-   # return the hex representation of digest
-   return h.hexdigest()
+	# return the hex representation of digest
+	return h.hexdigest()
 
 def downloadMod(packet,latest=False) :
 	global username, token
@@ -204,16 +204,18 @@ def downloadMod(packet,latest=False) :
 		
 	url = "http://mods.factorio.com" + release["download_url"] + "?username=" + username + "&token=" + token
 	output_path = "mod_cache" + os.sep + release["file_name"]
+
 	if os.path.isfile(output_path):
 		sha1 = release['sha1']
-		if sha1==hash_file(output_path):
+
+		if sha1 == hash_file(output_path):
 			print('Using cached version')
 			return release["file_name"]
-		
+
 	request = requests.get(url)
 	request.raise_for_status()
+
 	with open(output_path, "wb") as file:
-		
 		for chunk in request.iter_content(4096) :
 			file.write(chunk)
 
@@ -268,7 +270,6 @@ def askModName(message="Insert mod name: ", error_message="Not found, try again"
 			continue
 		break
 	return packet
-		
 
 def start() :
 	global username, token, factorio_path
@@ -295,17 +296,15 @@ def start() :
 	if opt == 0 :
 		sys.exit(0)
 
-	if opt == 1 or opt ==2:
+	if opt in (1, 2):
 		if not checkCredentialsSet() :
 			print("You need to set the credentials in order to download a mod!")
 			return
+
 		if opt == 1 :
 			if not checkFactorioPathSet() :
 				print("You need to set the factorio path in order to install a mod!")
 				return
-			install_mod = True
-		elif opt == 2:
-			install_mod = False
 			
 		try :
 			packet = askModName()
@@ -314,10 +313,7 @@ def start() :
 			return
 
 		# downloadMod(packet)		
-		download_recursive_mod(packet['name'],install_mod=install_mod)
-		
-	
-		
+		download_recursive_mod(packet['name'], install_mod=opt == 1)
 	
 	elif opt == 3:
 		try :
@@ -376,6 +372,7 @@ try :
 		print(title)
 		checkDirs()
 		loadUserdata()
+
 		while True :
 			start()
 except KeyboardInterrupt:


### PR DESCRIPTION
First of all excellent script! I was looking for something like that to download all my mods.
I noticed that in the script there's no option to recursively download the dependencies, I have added that option but code still requires cleaning.
The unclean version works fine for me. I am creating the merge request if someone needs to use the extra features:

- Recursive dependency resolution
- Automatic factorio installation directory detection on Mac, Linux, and Windows. Tested only on Mac but should work fine for other platforms
- Implemented sha1 verification on redownloading mods. So if a mod is correctly downloaded once, no need to download it again.

Some behavioural changes:
In the interactive menu if a person selects to download mod it always downloads all the dependencies and latest releases are  chosen automatically.