### PR TITLE
Fix SSL error handling in download fallback mechanism

### DIFF
--- a/factoriomod.py
+++ b/factoriomod.py
@@ -300,10 +300,10 @@ def download_mod(packet, ver, filter=None):
 			if mirror != -1:
 				FALLBACK_MIRRORS[mirror][1] += 1
 
-			if i < len(urls):
-				raise
-			else:
+			if i < len(urls)-1:
 				continue
+			else:
+				raise
 	
 	if i != 0:
 		FALLBACK_MIRRORS.sort(key=lambda mirror: mirror[1])


### PR DESCRIPTION
## Description

When downloading mods from multiple mirror sources, if a specific mirror encounters an SSL error (e.g., certificate verification failure, connection timeout), the program currently raises an exception and terminates immediately. It fails to attempt the next available mirror, causing the entire download to fail even if other sources are functional.

## Root Cause

A logical inversion exists in the exception handling within `factoriomod.py` (lines 300-307):

### Current Logic (Incorrect):

```python
if i < len(urls):
    raise
else:
    continue
```

- It raises an exception while there are still remaining URLs to try (i < len(urls)).

- It attempts to continue only when it reaches the end of the list (i >= len(urls)), where no more mirrors exist.

## Solution

The logic has been corrected to ensure a proper failover mechanism:

### Corrected Logic:

```python
if i < len(urls) - 1:
    continue
else:
    raise
```

- If more URLs are available, the loop now correctly continues to the next mirror.
- An exception is only raised after all mirror sources have been exhausted.

## Type of Change

- [x] Bug fix

## Testing

- [x] Manually verified and tested in a **Python 3.14** environment.
- [x] Confirmed that the program correctly skips a failed mirror and proceeds to the next one upon encountering an SSL error.
